### PR TITLE
Define dump_config for compatibility with newer Git::Repo

### DIFF
--- a/lib/Dist/Zilla/App/CommandHelper/ChainSmoking.pm
+++ b/lib/Dist/Zilla/App/CommandHelper/ChainSmoking.pm
@@ -30,6 +30,8 @@ has branch => ( isa => 'Str', is => 'ro', lazy => 1, default => sub {
 
 ### HACK: Needed for DirtyFiles, though this is really only used for Plugins ###
 sub mvp_multivalue_args { }
+### HACK: Ditto for ...::Git::Repo (expects 'Dist::Zilla::Role::ConfigDumper').
+sub dump_config { return {} }
 
 with 'Dist::Zilla::Role::Git::Repo';
 with 'Dist::Zilla::Role::Git::DirtyFiles';


### PR DESCRIPTION
Dist::Zilla::Plugin::Git 2.021 added MetaConfig support for all its plugins.
...Git::Repo assumes consuming classes are plugins.

closes gh-16.
