### PR TITLE
Add --author flag to `dzil listdeps' in .travis.yml.

### DIFF
--- a/lib/Dist/Zilla/Role/TravisYML.pm
+++ b/lib/Dist/Zilla/Role/TravisYML.pm
@@ -219,8 +219,8 @@ sub build_travis_yml {
    ];
    $travis_code{dzil}{install} = scalar(@releases) ? \@releases_install : [
       "cpanm --quiet --notest --skip-satisfied Dist::Zilla",  # this should already exist anyway...
-      "dzil authordeps --missing | grep -vP '[^\\w:]' | ".($self->test_authordeps ? $test_cmd : $notest_cmd),
-      "dzil listdeps   --missing | grep -vP '[^\\w:]' | ".($self->test_deps       ? $test_cmd : $notest_cmd),
+      "dzil authordeps          --missing | grep -vP '[^\\w:]' | ".($self->test_authordeps ? $test_cmd : $notest_cmd),
+      "dzil listdeps   --author --missing | grep -vP '[^\\w:]' | ".($self->test_deps       ? $test_cmd : $notest_cmd),
    ];
    $travis_code{dzil}{script} = [
       "dzil smoke --release --author",


### PR DESCRIPTION
At the some point, dependent modules for some author/release tests included in the Dist::Zilla bundle become NOT optional:
https://github.com/rjbs/Dist-Zilla/commit/b1eac573e8e2e0271e18aba27633e9c548c1da6f

On the other hand, the dependencies are added only as develop phase:
https://github.com/rjbs/Dist-Zilla/blob/master/lib/Dist/Zilla/Plugin/PodCoverageTests.pm#L28

So, `dzil listdeps` is not enough to make sure to install dependencies for author/release tests.

By the changes of this pull request, the following failure:
https://travis-ci.org/yak1ex/String-Unescape/jobs/24317647#L225
is recovered as:
https://travis-ci.org/yak1ex/String-Unescape/jobs/24319839#L311

(Please ignore failure of t/release-kwalitee.t: 22. To tell the truth, it is related with the DZ changes described at the beginning of this comment, but not related with Dist-Zilla-TravisCI)
