### PR TITLE
Load CommandHelper lazily.

### DIFF
--- a/lib/Dist/Zilla/App/Command/chainsmoke.pm
+++ b/lib/Dist/Zilla/App/Command/chainsmoke.pm
@@ -7,7 +7,6 @@ package Dist::Zilla::App::Command::chainsmoke;
 use sanity;
 
 use Dist::Zilla::App -command;
-use Dist::Zilla::App::CommandHelper::ChainSmoking;
 
 sub opt_spec {
    return (
@@ -21,6 +20,9 @@ sub abstract { 'continuously smoke your dist on your CI server' }
 
 sub execute {
    my ($self, $opt) = @_;
+
+   require Dist::Zilla::App::CommandHelper::ChainSmoking;
+
    my $cs = Dist::Zilla::App::CommandHelper::ChainSmoking->new( app => $self->app );
    my $gb = $cs->git_bundle;
 


### PR DESCRIPTION
This one line for me on my machine consitutes a whopping **50** percent
of the `dzil nop` time in an empty directory.

Without this line commented out:

```
strace -e trace=open dzil nop |& wc -l
668

time for i in 1 2 3 4 5; do dzil nop; done
real   0m9.671s
user   0m9.068s
sys    0m0.596s
cpu    99.94%
```

With this line commented out and done lazily when needed:

```
strace -e trace=open dzil nop |& wc -l
473

time for i in 1 2 3 4 5; do dzil nop; done
real   0m5.263s
user   0m4.848s
sys    0m0.412s
cpu    99.95%
```

The only downside of this patch is there's a growth of this new warning
which I don't grok because I have no idea where its comming from:

```
(in cleanup) Can't use an undefined value as an ARRAY reference at /home/kent/perl5/perlbrew/perls/blead/lib/5.21.3/autodie/Scope/GuardStack.pm line 47 during global destruction.
```

Fortunately, that is reasonably straight forward to fix and get even
more performance from by removing `use sanity`

```
strace -e trace=open dzil nop  |& wc -l
446

time for i in 1 2 3 4 5; do dzil nop; done
real   0m4.096s
user   0m3.765s
sys    0m0.328s
cpu    99.95%
```

Yeah. That 'sanity' consitutes a sizable portion of startup cost too.
