### PR TITLE
Remove dependency on Moose::Autobox

### DIFF
--- a/lib/Dist/Zilla/App/CommandHelper/ChainSmoking.pm
+++ b/lib/Dist/Zilla/App/CommandHelper/ChainSmoking.pm
@@ -98,13 +98,11 @@ sub prebuild {
    my $self = shift;
    my $zilla = $self->zilla;
 
-   use Moose::Autobox 0.09; # ->flatten
-
-   $_->before_build     for $zilla->plugins_with(-BeforeBuild )->flatten;
-   $_->gather_files     for $zilla->plugins_with(-FileGatherer)->flatten;
-   $_->prune_files      for $zilla->plugins_with(-FilePruner  )->flatten;
-   $_->munge_files      for $zilla->plugins_with(-FileMunger  )->flatten;
-   $_->register_prereqs for $zilla->plugins_with(-PrereqSource)->flatten;
+   $_->before_build     for @{ $zilla->plugins_with(-BeforeBuild ) };
+   $_->gather_files     for @{ $zilla->plugins_with(-FileGatherer) };
+   $_->prune_files      for @{ $zilla->plugins_with(-FilePruner  ) };
+   $_->munge_files      for @{ $zilla->plugins_with(-FileMunger  ) };
+   $_->register_prereqs for @{ $zilla->plugins_with(-PrereqSource) };
 
    $zilla->prereqs->finalize;
 }


### PR DESCRIPTION
its dependency autobox is making testing needlessly hard after perl blead 5.21.6 at this time.

Unfortunately, I was unable to test this patch either with prove or with dzil test because I am unable to install many of the dependencies your bundle requires.

See also: https://github.com/doherty/Dist-Zilla-Plugin-Test-CPAN-Changes/pull/5 