### PR TITLE
Suppport Travis CI containerisation infrastructure

### DIFF
--- a/lib/Dist/Zilla/Plugin/TravisYML.pm
+++ b/lib/Dist/Zilla/Plugin/TravisYML.pm
@@ -91,6 +91,7 @@ __END__
    notify_email = 1
    notify_irc   = 0
    mvdt         = 0
+   sudo         = 0
 
    ; These options are probably a good idea
    ; if you are going to use a build_branch
@@ -256,6 +257,14 @@ branch), this option could be used to test that sort of branch.
 
 Because it can make the config (and Travis tests) kind of messy if you're not using them, the default
 is {0}.
+
+== sudo
+
+Tells Travis CI to use its faster to start container-based infrastrucure which only works with non-root
+access. If you need root access then set this to {1} and Travis CI will fall back to the tradional
+infrastructure.
+
+The default is {0}.
 
 == Custom Commands
 

--- a/lib/Dist/Zilla/Role/TravisYML.pm
+++ b/lib/Dist/Zilla/Role/TravisYML.pm
@@ -39,6 +39,7 @@ our @phases = qw(
    after_deploy
 );
 my @yml_order = (qw(
+   sudo
    language
    perl
    env
@@ -64,6 +65,7 @@ has mvdt             => ( rw, isa => Bool,          default => 0              );
 has test_authordeps  => ( rw, isa => Bool,          default => 0              );
 has test_deps        => ( rw, isa => Bool,          default => 1              );
 has support_builddir => ( rw, isa => Bool,          default => 0              );
+has sudo             => ( rw, isa => Bool,          default => 0              );
 
 has irc_template  => ( rw, isa => ArrayRef[Str], default => sub { [
    "%{branch}#%{build_number} by %{author}: %{message} (%{build_url})",
@@ -123,6 +125,7 @@ sub build_travis_yml {
    my ($self, $is_build_branch) = @_;
 
    my %travis_yml = (
+      sudo     => $self->sudo ? 'true' : 'false',
       language => 'perl',
       matrix   => { fast_finish => 'true' },
       $self->support_builddir ? (


### PR DESCRIPTION
This is done by supporting the sudo directive, defaulting to 0
for container support, as an optional parametre to TravisYML