### PR TITLE
add 5.22 and 5.24 to default perl_version string

### DIFF
--- a/lib/Dist/Zilla/Role/TravisYML.pm
+++ b/lib/Dist/Zilla/Role/TravisYML.pm
@@ -70,7 +70,7 @@ has irc_template  => ( rw, isa => ArrayRef[Str], default => sub { [
    "%{branch}#%{build_number} by %{author}: %{message} (%{build_url})",
 ] } );
 
-has perl_version       => ( rw, isa => Str, default => '-blead 5.20 5.18 5.16 5.14 5.12 5.10 -5.8' );
+has perl_version       => ( rw, isa => Str, default => '-blead 5.24 5.22 5.20 5.18 5.16 5.14 5.12 5.10 -5.8' );
 has perl_version_build => ( rw, isa => Str, lazy, default => sub { shift->perl_version } );
 
 has _releases => ( ro, isa => ArrayRef[Str], lazy, default => sub {


### PR DESCRIPTION
The TravisYML docs say that the default perl_version is:

"The default is all of the major stable releases of Perl from 5.8 on up,"

I was surprised that 5.22 and 5.24 were not included by default.  This patch fixes this problem.