### PR TITLE
add 5.22 and 5.24 to default perl_version string

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ sudo: false
 language: perl
 perl:
    - 'blead'
+   - '5.24'
+   - '5.22'
    - '5.20'
    - '5.18'
    - '5.16'

--- a/lib/Dist/Zilla/Role/TravisYML.pm
+++ b/lib/Dist/Zilla/Role/TravisYML.pm
@@ -70,7 +70,7 @@ has irc_template  => ( rw, isa => ArrayRef[Str], default => sub { [
    "%{branch}#%{build_number} by %{author}: %{message} (%{build_url})",
 ] } );
 
-has perl_version       => ( rw, isa => Str, default => '-blead 5.20 5.18 5.16 5.14 5.12 5.10 -5.8' );
+has perl_version       => ( rw, isa => Str, default => '-blead 5.24 5.22 5.20 5.18 5.16 5.14 5.12 5.10 -5.8' );
 has perl_version_build => ( rw, isa => Str, lazy, default => sub { shift->perl_version } );
 
 has _releases => ( ro, isa => ArrayRef[Str], lazy, default => sub {

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -86,7 +86,7 @@ test_travis_yml(
 # Perl version testing
 test_travis_yml(
    {},
-   perl   => [ qw(blead 5.20 5.18 5.16 5.14 5.12 5.10 5.8) ],
+   perl   => [ qw(blead 5.24 5.22 5.20 5.18 5.16 5.14 5.12 5.10 5.8) ],
    matrix => {
       fast_finish    => 'true',
       allow_failures => [ { perl => 'blead' }, { perl => '5.8' } ],
@@ -107,7 +107,7 @@ test_travis_yml(
 test_travis_yml(
    { support_builddir => 1, perl_version_build => '5.8 -5.55' },
    env    => [ 'BUILD=0', 'BUILD=1' ],
-   perl   => [ qw(blead 5.20 5.18 5.16 5.14 5.12 5.10 5.8 5.55) ],
+   perl   => [ qw(blead 5.24 5.22 5.20 5.18 5.16 5.14 5.12 5.10 5.8 5.55) ],
    matrix => {
       fast_finish    => 'true',
       allow_failures => [


### PR DESCRIPTION
Add stable 5.22 and 5.24 to the default perl_version string.

The TravisYML plugin docs say that the default perl_verison is:

"The default is all of the major stable releases of Perl from 5.8 on up,..."

This makes the plugin do what the docs say as 5.22 and 5.24 are stable releases.