### PR TITLE
Fix swapped perl_version and perl_version_build

### DIFF
--- a/lib/Dist/Zilla/Role/TravisYML.pm
+++ b/lib/Dist/Zilla/Role/TravisYML.pm
@@ -155,7 +155,7 @@ sub build_travis_yml {
       );
    }
    else {
-      @perls = split(/\s+/, $is_build_branch ? $self->perl_version : $self->perl_version_build);
+      @perls = split(/\s+/, $is_build_branch ? $self->perl_version_build : $self->perl_version);
       @perls_allow_failures =
          map { +{ perl => $_ } }
          grep { s/^\-// }  # also strips the dash from @perls


### PR DESCRIPTION
This fixes a bug where the perl_version and perl_version_build options are
mistakenly crossed (happens only if not using support_builddir).

I'd add a test, but the authordeps aren't installing for me at the moment...